### PR TITLE
Add JSON function_call tests

### DIFF
--- a/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
@@ -338,3 +338,35 @@ const isEmptyTextContent = (block: AssistantMessageContent) =>
 		})
 	})
 })
+describe("parseAssistantMessageV2 JSON function_call", () => {
+	it("should parse JSON function_call into ToolUse", () => {
+		const json = JSON.stringify({
+			function_call: {
+				name: "read_file",
+				arguments: JSON.stringify({ path: "src/file.ts" }),
+			},
+		})
+		const result = parseAssistantMessageV2(json)
+		expect(result).toHaveLength(1)
+		const toolUse = result[0] as ToolUse
+		expect(toolUse.type).toBe("tool_use")
+		expect(toolUse.name).toBe("read_file")
+		expect(toolUse.params.path).toBe("src/file.ts")
+		expect(toolUse.partial).toBe(false)
+	})
+
+	it("should parse JSON function_call with multiple params", () => {
+		const json = JSON.stringify({
+			function_call: {
+				name: "read_file",
+				arguments: JSON.stringify({ path: "src/file.ts", start_line: 1, end_line: 10 }),
+			},
+		})
+		const result = parseAssistantMessageV2(json)
+		expect(result).toHaveLength(1)
+		const toolUse = result[0] as ToolUse
+		expect(toolUse.params.path).toBe("src/file.ts")
+		expect(toolUse.params.start_line).toBe("1")
+		expect(toolUse.params.end_line).toBe("10")
+	})
+})


### PR DESCRIPTION
## Summary
- extend `parseAssistantMessageV2` to handle OpenAI `function_call` JSON
- test JSON function calls in assistant message parser
- add end-to-end task test verifying tool handler invoked for `function_call`

## Testing
- `./src/node_modules/.bin/jest -c src/jest.config.mjs src/core/assistant-message/__tests__/parseAssistantMessage.test.ts src/core/task/__tests__/Task.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68402cb5aa30832faa09f23096fc3cc9