### PR TITLE
Add native tool call setting

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -58,6 +58,7 @@ const baseProviderSettingsSchema = z.object({
 	fuzzyMatchThreshold: z.number().optional(),
 	modelTemperature: z.number().nullish(),
 	rateLimitSeconds: z.number().optional(),
+	useNativeToolCalls: z.boolean().optional(),
 
 	// Model reasoning.
 	enableReasoningEffort: z.boolean().optional(),
@@ -347,6 +348,7 @@ export const PROVIDER_SETTINGS_KEYS = keysOf<ProviderSettings>()([
 	"fuzzyMatchThreshold",
 	"modelTemperature",
 	"rateLimitSeconds",
+	"useNativeToolCalls",
 	// Fake AI
 	"fakeAi",
 	// X.AI (Grok)

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -7,6 +7,7 @@ import {
 	providerSettingsSchemaDiscriminated,
 } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
+import { buildApiHandler } from "../../api"
 
 import { Mode, modes } from "../../shared/modes"
 
@@ -460,6 +461,17 @@ export class ProviderSettingsManager {
 				},
 				{} as Record<string, ProviderSettingsWithId>,
 			)
+
+			for (const [_name, apiConfig] of Object.entries(apiConfigs)) {
+				if (apiConfig.useNativeToolCalls === undefined) {
+					try {
+						const handler = buildApiHandler(apiConfig)
+						apiConfig.useNativeToolCalls = !!handler.getModel().info.supportsNativeToolCalling
+					} catch {
+						apiConfig.useNativeToolCalls = false
+					}
+				}
+			}
 
 			return {
 				...providerProfiles,

--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -236,7 +236,7 @@ describe("ProviderSettingsManager", () => {
 			const expectedConfig = {
 				currentApiConfigName: "default",
 				apiConfigs: {
-					default: {},
+					default: { useNativeToolCalls: false },
 					test: {
 						...newConfig,
 						id: testConfigId,
@@ -286,7 +286,7 @@ describe("ProviderSettingsManager", () => {
 			const expectedConfig = {
 				currentApiConfigName: "default",
 				apiConfigs: {
-					default: {},
+					default: { useNativeToolCalls: false },
 					test: {
 						...newConfig,
 						id: testConfigId,
@@ -443,7 +443,12 @@ describe("ProviderSettingsManager", () => {
 			const { name, ...providerSettings } = await providerSettingsManager.activateProfile({ name: "test" })
 
 			expect(name).toBe("test")
-			expect(providerSettings).toEqual({ apiProvider: "anthropic", apiKey: "test-key", id: "test-id" })
+			expect(providerSettings).toEqual({
+				apiProvider: "anthropic",
+				apiKey: "test-key",
+				id: "test-id",
+				useNativeToolCalls: false,
+			})
 
 			// Get the stored config to check the structure.
 			const storedConfig = JSON.parse(mockSecrets.store.mock.calls[1][1])
@@ -453,6 +458,7 @@ describe("ProviderSettingsManager", () => {
 				apiProvider: "anthropic",
 				apiKey: "test-key",
 				id: "test-id",
+				useNativeToolCalls: false,
 			})
 		})
 

--- a/src/core/config/__tests__/importExport.test.ts
+++ b/src/core/config/__tests__/importExport.test.ts
@@ -31,6 +31,7 @@ jest.mock("fs/promises", () => ({
 
 jest.mock("os", () => ({
 	homedir: jest.fn(() => "/mock/home"),
+	cpus: jest.fn(() => [1]),
 }))
 
 describe("importExport", () => {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1430,6 +1430,15 @@ export class ClineProvider
 		// Build the apiConfiguration object combining state values and secrets.
 		const providerSettings = this.contextProxy.getProviderSettings()
 
+		if (providerSettings.useNativeToolCalls === undefined) {
+			try {
+				const handler = buildApiHandler(providerSettings)
+				providerSettings.useNativeToolCalls = !!handler.getModel().info.supportsNativeToolCalling
+			} catch {
+				providerSettings.useNativeToolCalls = false
+			}
+		}
+
 		// Ensure apiProvider is set properly if not already in state
 		if (!providerSettings.apiProvider) {
 			providerSettings.apiProvider = apiProvider
@@ -1489,6 +1498,7 @@ export class ClineProvider
 			ttsEnabled: stateValues.ttsEnabled ?? false,
 			ttsSpeed: stateValues.ttsSpeed ?? 1.0,
 			diffEnabled: stateValues.diffEnabled ?? true,
+			useNativeToolCalls: providerSettings.useNativeToolCalls ?? false,
 			enableCheckpoints: stateValues.enableCheckpoints ?? true,
 			soundVolume: stateValues.soundVolume,
 			browserViewportSize: stateValues.browserViewportSize ?? "900x600",

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -1718,6 +1718,7 @@ describe("ClineProvider", () => {
 			const testApiConfig = {
 				apiProvider: "anthropic" as const,
 				apiKey: "test-key",
+				useNativeToolCalls: true,
 			}
 
 			// Trigger upsertApiConfiguration
@@ -1744,12 +1745,20 @@ describe("ClineProvider", () => {
 			await provider.resolveWebviewView(mockWebviewView)
 			const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
-			// Mock buildApiHandler to throw an error
+			// Mock buildApiHandler so first call succeeds for getState
+			// and second call throws an error when assigning to the task
 			const { buildApiHandler } = require("../../../api")
 
-			;(buildApiHandler as jest.Mock).mockImplementationOnce(() => {
-				throw new Error("API handler error")
-			})
+			;(buildApiHandler as jest.Mock)
+				.mockImplementationOnce(() => ({
+					getModel: () => ({ info: { supportsNativeToolCalling: false } }),
+				}))
+				.mockImplementationOnce(() => ({
+					getModel: () => ({ info: { supportsNativeToolCalling: false } }),
+				}))
+				.mockImplementationOnce(() => {
+					throw new Error("API handler error")
+				})
 			;(provider as any).providerSettingsManager = {
 				setModeConfig: jest.fn(),
 				saveConfig: jest.fn().mockResolvedValue(undefined),
@@ -1765,6 +1774,7 @@ describe("ClineProvider", () => {
 			const testApiConfig = {
 				apiProvider: "anthropic" as const,
 				apiKey: "test-key",
+				useNativeToolCalls: true,
 			}
 
 			// Trigger upsertApiConfiguration

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from "react"
 import { convertHeadersToObject } from "./utils/headers"
 import { useDebounce } from "react-use"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "vscrui"
 
 import {
 	type ProviderName,
@@ -488,6 +489,13 @@ const ApiOptions = ({
 						value={apiConfiguration.rateLimitSeconds || 0}
 						onChange={(value) => setApiConfigurationField("rateLimitSeconds", value)}
 					/>
+					<Checkbox
+						checked={apiConfiguration.useNativeToolCalls ?? false}
+						onChange={(checked: boolean) =>
+							setApiConfigurationField("useNativeToolCalls", checked === true)
+						}>
+						{t("settings:modelInfo.useNativeToolCalls")}
+					</Checkbox>
 				</>
 			)}
 		</div>

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -510,6 +510,7 @@
 		"cacheReadsPrice": "Cache reads price",
 		"cacheWritesPrice": "Cache writes price",
 		"enableStreaming": "Enable streaming",
+		"useNativeToolCalls": "Use native tool calls",
 		"enableR1Format": "Enable R1 model parameters",
 		"enableR1FormatTips": "Must be enabled when using R1 models such as QWQ to prevent 400 errors",
 		"useAzure": "Use Azure",


### PR DESCRIPTION
## Summary
- support `useNativeToolCalls` provider option
- default the setting based on model capability
- expose value in provider state
- add checkbox in provider settings UI
- fix test expectations and mocks

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_b_68402cac8e84832fa16fa274705b21d2