### PR TITLE
Support native tool_use output from VSCode LM

### DIFF
--- a/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
@@ -346,7 +346,7 @@ describe("parseAssistantMessageV2 JSON function_call", () => {
 				arguments: JSON.stringify({ path: "src/file.ts" }),
 			},
 		})
-		const result = parseAssistantMessageV2(json)
+		const result = parseAssistantMessageV2(json, true)
 		expect(result).toHaveLength(1)
 		const toolUse = result[0] as ToolUse
 		expect(toolUse.type).toBe("tool_use")
@@ -362,11 +362,11 @@ describe("parseAssistantMessageV2 JSON function_call", () => {
 				arguments: JSON.stringify({ path: "src/file.ts", start_line: 1, end_line: 10 }),
 			},
 		})
-		const result = parseAssistantMessageV2(json)
+		const result = parseAssistantMessageV2(json, true)
 		expect(result).toHaveLength(1)
 		const toolUse = result[0] as ToolUse
 		expect(toolUse.params.path).toBe("src/file.ts")
-		expect(toolUse.params.start_line).toBe("1")
-		expect(toolUse.params.end_line).toBe("10")
+		expect(toolUse.params.start_line).toBe(1)
+		expect(toolUse.params.end_line).toBe(10)
 	})
 })

--- a/src/core/task/__tests__/Task.test.ts
+++ b/src/core/task/__tests__/Task.test.ts
@@ -862,8 +862,8 @@ describe("Cline", () => {
 			const { parseAssistantMessageV2 } = require("../../assistant-message/parseAssistantMessageV2")
 			const readFileModule = require("../../tools/readFileTool")
 			const readFileSpy = jest.spyOn(readFileModule, "readFileTool").mockResolvedValue(undefined)
-			jest.spyOn(require("../../assistant-message"), "parseAssistantMessage").mockImplementation(
-				parseAssistantMessageV2,
+			jest.spyOn(require("../../assistant-message"), "parseAssistantMessage").mockImplementation((msg: string) =>
+				parseAssistantMessageV2(msg, true),
 			)
 
 			const [cline, task] = Task.create({


### PR DESCRIPTION
## Summary
- support `useNativeToolCalls` in VSCode LM provider
- document native `tool_use` behaviour in provider docs
- test native path for VSCode LM provider
- update JSON parsing tests for native tool calls

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_684070e7b040832f8170a048cf0419c4