### PR TITLE
Fix OpenAI tool schema format

### DIFF
--- a/src/core/prompts/tools/index.ts
+++ b/src/core/prompts/tools/index.ts
@@ -202,7 +202,13 @@ export function buildToolSchemas(
 
 	const schemas = Array.from(tools).map((toolName) => {
 		const schemaFn = toolSchemaMap[toolName]
-		return schemaFn ? schemaFn(args) : undefined
+		const schema = schemaFn ? schemaFn(args) : undefined
+		return schema
+			? {
+					type: "function" as const,
+					function: schema,
+				}
+			: undefined
 	})
 
 	return schemas.filter(Boolean)


### PR DESCRIPTION
## Summary
- fix buildToolSchemas to wrap tool descriptions in ChatCompletionTool format

## Testing
- `npm test` *(fails: Unsupported engine and other issues)*

------
https://chatgpt.com/codex/tasks/task_b_68430ee61bc8832f8b7a22290e2050ce