### PR TITLE
Fix provider schema union

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -202,9 +202,11 @@ const litellmSchema = baseProviderSettingsSchema.extend({
 	litellmModelId: z.string().optional(),
 })
 
-const defaultSchema = z.object({
-	apiProvider: z.undefined(),
-})
+const defaultSchema = baseProviderSettingsSchema.merge(
+	z.object({
+		apiProvider: z.undefined(),
+	}),
+)
 
 export const providerSettingsSchemaDiscriminated = z.discriminatedUnion("apiProvider", [
 	anthropicSchema.merge(z.object({ apiProvider: z.literal("anthropic") })),


### PR DESCRIPTION
## Summary
- include base fields in default provider schema so `useNativeToolCalls` is optional

## Testing
- `pnpm lint`
- `pnpm check-types` *(fails: @roo-code/web-evals#check-types)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68431b6402c4832f976c01d05657f850